### PR TITLE
Support copying to clipboard, and paste by default into the current tab's domain.

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -132,7 +132,7 @@
                 color: #756e6e;
             }
         </style>
-        <script src="popup.js"></script>
+        <script src="popup.js" type="module"></script>
     </head>
     <body>
         <span class="versionLabel">v2.0.1</span>
@@ -152,6 +152,7 @@
                 </div>
                 <div class="buttonWrapper">
                     <button id="copyButton">Copy</button>
+                    <button id="copyToClipboard">To Clipboard</button>
                 </div>
             </div>
             <div class="formWrapper2">


### PR DESCRIPTION
The main changes include two modifications:

- Support for copying to the clipboard, which is sometimes needed.
- The default copied domain is the domain of the current tab's URL.

Most of the time, I copy cookies from one domain and then paste them into another tab. So here I use the domain name being pasted as the current URL's domain name, rather than localhost, which mainly simplifies the need for manual input.